### PR TITLE
Pipeline Hook renamed Pipeline Event

### DIFF
--- a/gitlab-rocketchat.hooks.js
+++ b/gitlab-rocketchat.hooks.js
@@ -40,6 +40,7 @@ class Script { // eslint-disable-line
 					result = this.tagEvent(request.content);
 					break;
 				case 'Pipeline Hook':
+				case 'Pipeline Event':
 					result = this.pipelineEvent(request.content);
 					break;
 				case 'Build Hook':


### PR DESCRIPTION
GitLab CE 9.5+ seems to be using 'Pipeline Event' instead of 'Pipeline Hook' in the "x-gitlab-event" field.  This change should be backwards compatible with previous versions of GitLab CE.  I have not checked/tested other hooks to see if they were renamed as I have only been concerned about the 'Pipeline Event' webhook.