### PR TITLE
add new job hook case for GitLab >= 9.3.0

### DIFF
--- a/gitlab-rocketchat.hooks.js
+++ b/gitlab-rocketchat.hooks.js
@@ -72,9 +72,7 @@ class Script { // eslint-disable-line
 				case 'Pipeline Event':
 					result = this.pipelineEvent(request.content);
 					break;
-				case 'Build Hook': // GitLab < 9.3
-					result = this.buildEvent(request.content);
-					break;
+				case 'Build Hook': // GitLab < 9.3.0
 				case 'Job Hook': // GitLab >= 9.3.0
 					result = this.buildEvent(request.content);
 					break;

--- a/gitlab-rocketchat.hooks.js
+++ b/gitlab-rocketchat.hooks.js
@@ -72,7 +72,10 @@ class Script { // eslint-disable-line
 				case 'Pipeline Event':
 					result = this.pipelineEvent(request.content);
 					break;
-				case 'Build Hook':
+				case 'Build Hook': // GitLab < 9.3
+					result = this.buildEvent(request.content);
+					break;
+				case 'Job Hook': // GitLab >= 9.3.0
 					result = this.buildEvent(request.content);
 					break;
 				case 'Wiki Page Hook':


### PR DESCRIPTION
Gitlab >= 9.3.0 uses  'Job Hook' instead of 'Build Hook'.