### PR TITLE
Make sure mentions in Gitlab comments become mentions in Rocket Chat

### DIFF
--- a/gitlab-rocketchat.hooks.js
+++ b/gitlab-rocketchat.hooks.js
@@ -208,8 +208,8 @@ See: ${data.object_attributes.url}`,
     let rocket_text = at.join('')
     const mentions = comment.note.match(/(@[a-zA-Z]*)/g)
     if (mentions !== null) {
-      mentions.reduce((r, i) => { return r += ' ' + i; }, '').substring(1)
-      rocket_text += '\nmentions: ' + mentions
+      const reduced = mentions.reduce((r, i) => { return r += ' ' + i; }, '').substring(1)
+      rocket_text += '\nmentions: ' + reduced
     }
         
 		return {

--- a/gitlab-rocketchat.hooks.js
+++ b/gitlab-rocketchat.hooks.js
@@ -205,13 +205,20 @@ See: ${data.object_attributes.url}`,
 			const snippet = data.snippet;
 			text = `commented on code snippet [#${snippet.id} ${snippet.title}](${comment.url})`;
 		}
+    let rocket_text = at.join('')
+    const mentions = comment.note.match(/(@[a-zA-Z]*)/g)
+    if (mentions !== null) {
+      mentions.reduce((r, i) => { return r += ' ' + i; }, '').substring(1)
+      rocket_text += '\nmentions: ' + mentions
+    }
+        
 		return {
 			content: {
 				username: 'gitlab/' + project.name,
 				icon_url: USE_ROCKETCHAT_AVATAR ? null : avatar,
-				text: at.join(' '),
+				text: rocket_text,
 				attachments: [
-					makeAttachment(user, `${text}\n${comment.note}`, comment.updated_at)
+					makeAttachment(user, `${text}\n${comment.note}`, comment.updated_at)                  	
 				]
 			}
 		};


### PR DESCRIPTION
This PR will look for mentions in Gitlab comments and set a text area in Rocket Chat message so that it actually becomes a real mention in Rocket Chat as well.
